### PR TITLE
add _children and _parent + call options._diff

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
     "jest": "^26.0.0",
     "lint-staged": "^11.0.1",
     "microbundle": "^0.13.3",
-    "preact": "10.5.14",
-    "preact-render-to-string": "^5.1.19",
+    "preact": "10.11.0",
+    "preact-render-to-string": "^5.2.4",
     "prettier": "^2.0.5",
     "rimraf": "3.0.2",
     "typescript": "^4.3.5"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "test": "yarn test:flow && yarn test:unit",
     "test:flow": "flow check",
-    "test:unit": "jest --coverage --roots src",
+    "test:unit": "jest --coverage --roots src --runInBand",
     "test:unit:watch": "jest --coverage --watch --roots src",
     "test:unit:travis": "yarn test:unit --coverageReporters=text-lcov | yarn coveralls",
     "test:ts": "tsc -p typings/tsconfig.json",

--- a/src/index.js
+++ b/src/index.js
@@ -26,7 +26,7 @@ type Options = {
 };
 */
 
-export default async function prepass(
+export default function prepass(
 	vnode /*: VNode */,
 	visitor /*: ?(vnode: VNode, component: typeof Component) => ?Promise<any> */,
 	context /*: ?Object */,
@@ -152,21 +152,19 @@ export default async function prepass(
 					visitor(vnode, isClassComponent ? c : undefined) || Promise.resolve()
 			  ).then(doRender)
 			: doRender()
-		).then(async (rendered) => {
+		).then((rendered) => {
 			if (c.getChildContext) {
 				context = assign(assign({}, context), c.getChildContext());
 			}
 
 			if (Array.isArray(rendered)) {
 				vnode[_children] = [];
-				const result = await Promise.all(
+				return Promise.all(
 					rendered.map((node) => {
 						vnode[_children].push(node);
 						return prepass(node, visitor, context, vnode)
 					})
 				);
-				if (options.unmount) options.unmount(vnode)
-				return result;
 			}
 
 			return prepass(rendered, visitor, context, vnode);
@@ -177,16 +175,12 @@ export default async function prepass(
 
 	if (props && getChildren((children = []), props.children).length) {
 		vnode[_children] = [];
-		const result = await Promise.all(
+		return Promise.all(
 			children.map((child) => {
 				vnode[_children].push(child);
 				return prepass(child, visitor, context, vnode)
 			})
 		);
-
-		if (options.unmount) options.unmount(vnode)
-
-		return result;
 	}
 
 	return Promise.resolve();

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ type VNode = {
 	props: Object,
 	__c: typeof Component,
 	__: any,
-	__c: any,
+	__k: any,
 };
 
 type VNodes = VNode | Array<VNode>;

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -9,7 +9,7 @@ import {
 	Component,
 } from "preact";
 import prepass from ".";
-import { useState, useEffect, useLayoutEffect } from "preact/hooks";
+import { useState, useEffect, useLayoutEffect, useId } from "preact/hooks";
 import { lazy, Suspense } from "preact/compat";
 import renderToString from "preact-render-to-string";
 
@@ -1121,6 +1121,31 @@ describe("prepass", () => {
 			expect(setDirtyFromPreactCore).toHaveBeenCalledTimes(1);
 		});
 	});
+
+	describe("useId", () => {
+		it('should generate unique ids', async () => {
+			const ids = []
+			const Child = () => {
+				const id = useId();
+				ids.push(id)
+				return <input id={id} />
+			}
+
+			const App = () => {
+				const id = useId();
+				ids.push(id)
+				return (
+					<main id={id}>
+						<Child />
+					</main>
+				)
+			}
+
+			await prepass(<App />);
+
+			expect(ids).toEqual([])
+		})
+	})
 
 	describe("visitor", () => {
 		class MyClassComp extends Component {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -111,6 +111,131 @@ function createSuspendingComponent() {
 }
 
 describe("prepass", () => {
+	describe("hooks", () => {
+		// TODO: this seems to work but sais it's not
+		it.skip("should not enqueue components for re-rendering when using setState", async () => {
+			let didUpdate = false;
+
+			// a re-render would invoke an array sort on the render queue, thus lets check nothing does so
+			const arraySort = jest.spyOn(Array.prototype, "sort");
+
+			function MyHookedComponent() {
+				const [state, setState] = useState("foo");
+
+				if (!didUpdate) {
+					didUpdate = true;
+					throw new Promise((resolve) => {
+						setState("bar");
+						resolve();
+					});
+				}
+
+				return <div>{state}</div>;
+			}
+
+			const vnode = <MyHookedComponent />;
+
+			await prepass(vnode);
+			expect(arraySort).not.toHaveBeenCalled();
+
+			// let's test our test. If something changes in preact and no sort is executed
+			// before re-rendering our test would be false-positiv, thus we test that sort is called
+			// when c.__dirty is false
+
+			function MyHookedComponent2() {
+				const c = this;
+
+				const [state, setState] = useState("foo");
+
+				if (!didUpdate) {
+					didUpdate = true;
+					throw new Promise((resolve) => {
+						setState(() => {
+							c.__d = false;
+							return "bar";
+						});
+						resolve();
+					});
+				}
+
+				return <div>{state}</div>;
+			}
+
+			didUpdate = false;
+			const vnode2 = <MyHookedComponent2 />;
+
+			await prepass(vnode2);
+			expect(arraySort).toHaveBeenCalledTimes(1);
+			arraySort.mockRestore();
+		});
+
+		it("it should skip useEffect", async () => {
+			const spy = jest.fn();
+			function MyHookedComponent() {
+				useEffect(spy, []);
+
+				return <div />;
+			}
+
+			await prepass(<MyHookedComponent />);
+
+			expect(spy).not.toHaveBeenCalled();
+		});
+
+		it("it should skip useLayoutEffect", async () => {
+			const spy = jest.fn();
+			function MyHookedComponent() {
+				useLayoutEffect(spy, []);
+
+				return <div />;
+			}
+
+			await prepass(<MyHookedComponent />);
+
+			expect(spy).not.toHaveBeenCalled();
+		});
+
+		it("it should reset _skipEffects", async () => {
+			function MyHookedComponent() {
+				useLayoutEffect(() => {}, []);
+
+				return <div />;
+			}
+
+			options.__s = "test";
+			await prepass(<MyHookedComponent />);
+			expect(options.__s).toEqual("test");
+		});
+
+		describe("useId", () => {
+			it('should generate unique ids', async () => {
+				const ids = []
+				const Child = () => {
+					const id = useId();
+					ids.push(id)
+					return <input id={id} />
+				}
+
+				const App = () => {
+					const id = useId();
+					ids.push(id)
+					return (
+						<main id={id}>
+							<Child />
+						</main>
+					)
+				}
+
+				await prepass(<App />);
+
+				expect(ids).toEqual([
+					"P481",
+					"P15361",
+				])
+			})
+		})
+	});
+
 	describe("rendering", () => {
 		it("should pass props to render", async () => {
 			const Component = jest.fn(() => <div />);
@@ -276,103 +401,6 @@ describe("prepass", () => {
 			);
 
 			expect(true).toEqual(true);
-		});
-	});
-
-	describe("hooks", () => {
-		// TODO: this seems to work but sais it's not
-		it.skip("should not enqueue components for re-rendering when using setState", async () => {
-			let didUpdate = false;
-
-			// a re-render would invoke an array sort on the render queue, thus lets check nothing does so
-			const arraySort = jest.spyOn(Array.prototype, "sort");
-
-			function MyHookedComponent() {
-				const [state, setState] = useState("foo");
-
-				if (!didUpdate) {
-					didUpdate = true;
-					throw new Promise((resolve) => {
-						setState("bar");
-						resolve();
-					});
-				}
-
-				return <div>{state}</div>;
-			}
-
-			const vnode = <MyHookedComponent />;
-
-			await prepass(vnode);
-			expect(arraySort).not.toHaveBeenCalled();
-
-			// let's test our test. If something changes in preact and no sort is executed
-			// before re-rendering our test would be false-positiv, thus we test that sort is called
-			// when c.__dirty is false
-
-			function MyHookedComponent2() {
-				const c = this;
-
-				const [state, setState] = useState("foo");
-
-				if (!didUpdate) {
-					didUpdate = true;
-					throw new Promise((resolve) => {
-						setState(() => {
-							c.__d = false;
-							return "bar";
-						});
-						resolve();
-					});
-				}
-
-				return <div>{state}</div>;
-			}
-
-			didUpdate = false;
-			const vnode2 = <MyHookedComponent2 />;
-
-			await prepass(vnode2);
-			expect(arraySort).toHaveBeenCalledTimes(1);
-			arraySort.mockRestore();
-		});
-
-		it("it should skip useEffect", async () => {
-			const spy = jest.fn();
-			function MyHookedComponent() {
-				useEffect(spy, []);
-
-				return <div />;
-			}
-
-			await prepass(<MyHookedComponent />);
-
-			expect(spy).not.toHaveBeenCalled();
-		});
-
-		it("it should skip useLayoutEffect", async () => {
-			const spy = jest.fn();
-			function MyHookedComponent() {
-				useLayoutEffect(spy, []);
-
-				return <div />;
-			}
-
-			await prepass(<MyHookedComponent />);
-
-			expect(spy).not.toHaveBeenCalled();
-		});
-
-		it("it should reset _skipEffects", async () => {
-			function MyHookedComponent() {
-				useLayoutEffect(() => {}, []);
-
-				return <div />;
-			}
-
-			options.__s = "test";
-			await prepass(<MyHookedComponent />);
-			expect(options.__s).toEqual("test");
 		});
 	});
 
@@ -1121,34 +1149,6 @@ describe("prepass", () => {
 			expect(setDirtyFromPreactCore).toHaveBeenCalledTimes(1);
 		});
 	});
-
-	describe("useId", () => {
-		it('should generate unique ids', async () => {
-			const ids = []
-			const Child = () => {
-				const id = useId();
-				ids.push(id)
-				return <input id={id} />
-			}
-
-			const App = () => {
-				const id = useId();
-				ids.push(id)
-				return (
-					<main id={id}>
-						<Child />
-					</main>
-				)
-			}
-
-			await prepass(<App />);
-
-			expect(ids).toEqual([
-				"P481",
-				"P15361",
-			])
-		})
-	})
 
 	describe("visitor", () => {
 		class MyClassComp extends Component {

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1143,7 +1143,10 @@ describe("prepass", () => {
 
 			await prepass(<App />);
 
-			expect(ids).toEqual([])
+			expect(ids).toEqual([
+				"P481",
+				"P15361",
+			])
 		})
 	})
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5592,17 +5592,17 @@ postcss@^8.2.1:
     nanoid "^3.1.23"
     source-map-js "^0.6.2"
 
-preact-render-to-string@^5.1.19:
-  version "5.1.19"
-  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-5.1.19.tgz#ffae7c3bd1680be5ecf5991d41fe3023b3051e0e"
-  integrity sha512-bj8sn/oytIKO6RtOGSS/1+5CrQyRSC99eLUnEVbqUa6MzJX5dYh7wu9bmT0d6lm/Vea21k9KhCQwvr2sYN3rrQ==
+preact-render-to-string@^5.2.4:
+  version "5.2.4"
+  resolved "https://registry.yarnpkg.com/preact-render-to-string/-/preact-render-to-string-5.2.4.tgz#7d6a3f76e13fa9df8e81ccdef2f2b02489e5a3fd"
+  integrity sha512-iIPHb3BXUQ3Za6KNhkjN/waq11Oh+QWWtAgN3id3LrL+cszH3DYh8TxJPNQ6Aogsbu4JsqdJLBZltwPFpG6N6w==
   dependencies:
     pretty-format "^3.8.0"
 
-preact@10.5.14:
-  version "10.5.14"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.5.14.tgz#0b14a2eefba3c10a57116b90d1a65f5f00cd2701"
-  integrity sha512-KojoltCrshZ099ksUZ2OQKfbH66uquFoxHSbnwKbTJHeQNvx42EmC7wQVWNuDt6vC5s3nudRHFtKbpY4ijKlaQ==
+preact@10.11.0:
+  version "10.11.0"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.11.0.tgz#26af45a0613f4e17a197cc39d7a1ea23e09b2532"
+  integrity sha512-Fk6+vB2kb6mSJfDgODq0YDhMfl0HNtK5+Uc9QqECO4nlyPAQwCI+BKyWO//idA7ikV7o+0Fm6LQmNuQi1wXI1w==
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Getting this to work will be slightly challenging as _diff sets `currentComponent` to null and we call options._render asynchronously 😅 this is a bit messy... Peculiarly the tests do work in isolation.

Double checked in a csb and the output for useId is correct https://codesandbox.io/s/strange-kepler-q1tcwv?file=/src/index.js

EDIT: reordering tests did the trick for the asycn stuff 😅 

Fixes #46 