### PR TITLE
improve performance

### DIFF
--- a/src/index.test.js
+++ b/src/index.test.js
@@ -1035,7 +1035,7 @@ describe("prepass", () => {
 						// this checks whether the call comes from prepass or preact (core)
 						new Error().stack
 							.split("\n")[2]
-							.match(/^\s*at prepass \(.*\/src\/index\.js:[0-9]+:[0-9]+\)$/)
+							.match(/^\s*at _prepass \(.*\/src\/index\.js:[0-9]+:[0-9]+\)$/)
 					) {
 						// we want to force the failure case here to test that preact
 						// didn't change in a way invalidating our shady test method
@@ -1098,7 +1098,7 @@ describe("prepass", () => {
 						// this checks whether the call comes from prepass or preact (core)
 						new Error().stack
 							.split("\n")[2]
-							.match(/^\s*at prepass \(.*\/src\/index\.js:[0-9]+:[0-9]+\)$/)
+							.match(/^\s*at _prepass \(.*\/src\/index\.js:[0-9]+:[0-9]+\)$/)
 					) {
 						// we want to force the failure case here to test that preact
 						// didn't change in a way invalidating our shady test method

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -250,9 +250,7 @@ describe("prepass", () => {
 	});
 
 	it("should call options.render for function components", async () => {
-		const render = jest.fn();
 		const r = jest.fn();
-		options.render = render;
 		options.__r = r;
 		const Component = jest.fn(() => <div />);
 
@@ -261,14 +259,11 @@ describe("prepass", () => {
 		const result = await promise;
 		expect(result).toEqual(undefined);
 
-		expect(render).toHaveBeenCalledTimes(1);
 		expect(r).toHaveBeenCalledTimes(1);
 	});
 
 	it("should call options.render for class components", async () => {
-		const render = jest.fn();
 		const r = jest.fn();
-		options.render = render;
 		options.__r = r;
 
 		class Outer extends Component {
@@ -281,7 +276,6 @@ describe("prepass", () => {
 		await prepass(<Outer />);
 
 		expect(outerRenderSpy).toHaveBeenCalled();
-		expect(render).toHaveBeenCalledTimes(1);
 		expect(r).toHaveBeenCalledTimes(1);
 	});
 
@@ -780,19 +774,6 @@ describe("prepass", () => {
 		});
 
 		describe("preact options", () => {
-			it("should call options.render (legacy)", async () => {
-				const Suspendable = jest.fn(Suspendable_);
-				options.render = jest.fn();
-
-				const result = await prepass(
-					<Suspendable isDone={() => true}>Hello</Suspendable>
-				);
-				expect(options.render.mock.calls.length).toBe(1);
-				expect(result).toEqual([undefined]);
-
-				delete options.render;
-			});
-
 			it("should call options._render (__r)", async () => {
 				const Suspendable = jest.fn(Suspendable_);
 				options.__r = jest.fn();

--- a/src/util.js
+++ b/src/util.js
@@ -1,18 +1,6 @@
 // @flow
 
 /**
- * Copy all properties from `props` onto `obj`.
- * @param {object} obj Object onto which properties should be copied.
- * @param {object} props Object from which to copy properties.
- * @returns {object}
- * @private
- */
-export function assign(obj /*: Object */, props /*: Object */) /*: Object */ {
-	for (let i in props) obj[i] = props[i];
-	return obj;
-}
-
-/**
  * Get flattened children from the children prop
  * @param {Array} accumulator
  * @param {any} children A `props.children` opaque object.


### PR DESCRIPTION
This PR should not be merged as-is but instead is meant to spark some discussion, in the current iteration we pay twice for all `options.vnode` hooks which leaves us with a few options to counter-act this.

- we combine prepass and RTS in an async RTS
- we deprecate prepass and point people at straming
- we avoid paying for options.vnode in prepass but do in RTS

Note that options.vnode _only_ affects dom-nodes and the attributes thereof