### PR TITLE
Export typings from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "source": "src/index.js",
   "exports": {
     ".": {
+      "types": "./typings/index.d.ts",
       "browser": "./dist/index.module.js",
       "umd": "./dist/index.umd.js",
       "import": "./dist/index.mjs",


### PR DESCRIPTION
When I try to export `preact-ssr-prepass` to an application using nodeJs^18 I get an error:
```
Could not find a declaration file for module 'preact-ssr-prepass'. 
'.../node_modules/preact-ssr-prepass/dist/index.mjs' implicitly has an 'any' type.
There are types at '.../node_modules/preact-ssr-prepass/typings/index.d.ts', 
but this result could not be resolved when respecting package.json "exports". 
The 'preact-ssr-prepass' library may need to update its package.json or typings.
  ```
This happens because nodeJs^18 firstly looks at the exports field in package.json, but the types are not specified there.

[Description of main field](https://nodejs.org/api/packages.html#main):
> The "main" field defines the entry point of a package when imported by name via a node_modules lookup. Its value is a path. When a package has an ["exports"](https://nodejs.org/api/packages.html#exports) field, this will take precedence over the "main" field when importing the package by name.