### PR TITLE
chore: Disable Microbundle's type generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test:ts": "tsc -p typings/tsconfig.json",
     "build": "yarn build:clean && yarn build:bundle && yarn build:flow",
     "build:clean": "rimraf dist",
-    "build:bundle": "microbundle -i src/index.js --external preact --compress --strict --name preactSsrPrepass",
+    "build:bundle": "microbundle -i src/index.js --external preact --compress --strict --name preactSsrPrepass --no-generateTypes",
     "build:flow": "flow-copy-source -i '*.test.js' src/ dist/",
     "prepublishOnly": "yarn test && yarn build",
     "postbuild": "node ./config/node-13-exports.js"


### PR DESCRIPTION
Without this, Microbundle will overwrite the [hand-written types](https://github.com/preactjs/preact-ssr-prepass/blob/master/typings/index.d.ts) with the following:

```ts
export default function prepass(vnode: any, visitor: any, context: any, parent: any): any;
```