### PR TITLE
fix: `useId` past Preact 10.11.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "jest": "^26.0.0",
     "lint-staged": "^11.0.1",
     "microbundle": "^0.13.3",
-    "preact": "10.11.0",
+    "preact": "10.22.1",
     "preact-render-to-string": "^5.2.4",
     "prettier": "^2.0.5",
     "rimraf": "3.0.2",

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // @flow
 import { assign, getChildren } from "./util";
-import { options, Fragment, Component } from "preact";
+import { options, Fragment, Component, h } from "preact";
 import { Suspense } from "preact/compat";
 
 const createContextDefaultValue = "__p";
@@ -42,6 +42,10 @@ export default function prepass(
 		children = [];
 	context = context || {};
 
+	if (!parent) {
+		parent = h(Fragment, null);
+		parent[_children] = parent[vnode];
+	}
 	vnode[_parent] = parent;
 
 	if (

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -229,8 +229,8 @@ describe("prepass", () => {
 				await prepass(<App />);
 
 				expect(ids).toEqual([
-					"P481",
-					"P15361",
+					"P0-0",
+					"P0-1",
 				])
 			})
 		})

--- a/yarn.lock
+++ b/yarn.lock
@@ -5603,10 +5603,10 @@ preact-render-to-string@^5.2.4:
   dependencies:
     pretty-format "^3.8.0"
 
-preact@10.11.0:
-  version "10.11.0"
-  resolved "https://registry.yarnpkg.com/preact/-/preact-10.11.0.tgz#26af45a0613f4e17a197cc39d7a1ea23e09b2532"
-  integrity sha512-Fk6+vB2kb6mSJfDgODq0YDhMfl0HNtK5+Uc9QqECO4nlyPAQwCI+BKyWO//idA7ikV7o+0Fm6LQmNuQi1wXI1w==
+preact@10.22.1:
+  version "10.22.1"
+  resolved "https://registry.yarnpkg.com/preact/-/preact-10.22.1.tgz#6a3589973fe0c6e53211091607d31f4b7b27334d"
+  integrity sha512-jRYbDDgMpIb5LHq3hkI0bbl+l/TQ9UnkdQ0ww+lp+4MMOdqaUYdFc5qeyP+IV8FAd/2Em7drVPeKdQxsiWCf/A==
 
 prelude-ls@~1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Closes #60

An unimaginative copy what RTS did in https://github.com/preactjs/preact-render-to-string/pull/237